### PR TITLE
Added share target capabilities

### DIFF
--- a/CompactView/Activation/ProtocolActivationHandler.cs
+++ b/CompactView/Activation/ProtocolActivationHandler.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading.Tasks;
+
+using CompactView.Services;
+
+using Windows.ApplicationModel.Activation;
+
+namespace CompactView.Activation
+{
+    internal class ProtocolActivationHandler : ActivationHandler<ProtocolActivatedEventArgs>
+    {
+        private readonly Type _navElement;
+        private readonly long _iD;
+
+        public ProtocolActivationHandler(Type navElement, long iD)
+        {
+            _navElement = navElement;
+            _iD = iD;
+        }
+    
+        protected override async Task HandleInternalAsync(ProtocolActivatedEventArgs args)
+        {
+            // When the navigation stack isn't restored navigate to the first page,
+            // configuring the new page by passing required information as a navigation
+            // parameter
+            NavigationService.Navigate(_navElement, _iD.ToString());
+
+            await Task.CompletedTask;
+        }
+
+        protected override bool CanHandleInternal(ProtocolActivatedEventArgs args)
+        {
+            // Always accept new share intents
+            return true;
+        }
+    }
+}

--- a/CompactView/App.xaml.cs
+++ b/CompactView/App.xaml.cs
@@ -7,6 +7,8 @@ using Windows.ApplicationModel.Activation;
 using Windows.UI.Xaml;
 using CompactView.Helpers;
 using CompactView.Data;
+using Windows.ApplicationModel.DataTransfer.ShareTarget;
+using Windows.ApplicationModel.DataTransfer;
 
 namespace CompactView
 {
@@ -65,6 +67,18 @@ namespace CompactView
         private ActivationService CreateActivationService()
         {
             return new ActivationService(this, typeof(Views.WebViewPage), new Views.ShellPage());
+        }
+
+        protected override async void OnShareTargetActivated(ShareTargetActivatedEventArgs args)
+        {
+            ShareOperation shareOperation = args.ShareOperation;
+            if (shareOperation.Data.Contains(StandardDataFormats.WebLink))
+            {
+                Uri uri = await shareOperation.Data.GetWebLinkAsync();
+                await Windows.System.Launcher.LaunchUriAsync(new Uri("compactview:?"+Uri.EscapeDataString(uri.ToString())));
+
+            }
+            shareOperation.ReportCompleted();
         }
     }
 }

--- a/CompactView/CompactView.csproj
+++ b/CompactView/CompactView.csproj
@@ -118,6 +118,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Activation\ActivationHandler.cs" />
+    <Compile Include="Activation\ProtocolActivationHandler.cs" />
     <Compile Include="Data\Website.cs" />
     <Compile Include="Data\WebsiteDataSource.cs" />
     <Compile Include="Helpers\Json.cs" />

--- a/CompactView/Data/WebsiteDataSource.cs
+++ b/CompactView/Data/WebsiteDataSource.cs
@@ -39,7 +39,7 @@ namespace CompactView.Data
             //Returns either the first element in the list or a default page when the list is empty.
             public static Website GetDefault()
             {
-                if (_websites.Count == 0)
+            if (_websites.Count == 0)
                 {
                     return new Website() { Name = "Bing", URL = new Uri("https://www.bing.com/"), Symbol = Symbol.Globe };
                 }
@@ -62,7 +62,7 @@ namespace CompactView.Data
                 return website;
             }
 
-            public static void AddNewAsync(string name, Uri uRL)
+            public static async Task<long> AddNewAsync(string name, Uri uRL)
             {
                 long iD = Convert.ToInt64(DateTime.Now.Ticks);
                 Symbol symbol = Symbol.Globe;
@@ -70,7 +70,8 @@ namespace CompactView.Data
                 Website newSite = new Website() { ID = iD, Name = name, URL = uRL, Symbol = symbol };
 
                 _websites.Add(newSite);
-                SaveAsync(_websites);
+                await SaveAsync(_websites);
+                return iD;
             }
 
             public static void Delete(long iD)
@@ -110,5 +111,5 @@ namespace CompactView.Data
                 RoamingObjectStorageHelper helper = new RoamingObjectStorageHelper();
                 _websites = await helper.ReadFileAsync("keyWebsites", _websites);
             }
-        }
+    }
     }

--- a/CompactView/Package.appxmanifest
+++ b/CompactView/Package.appxmanifest
@@ -23,6 +23,18 @@
         </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
+      <Extensions>
+        <uap:Extension Category="windows.protocol">
+          <uap:Protocol Name="compactview">
+            <uap:DisplayName>Compact View</uap:DisplayName>
+          </uap:Protocol>
+        </uap:Extension>
+        <uap:Extension Category="windows.shareTarget">
+          <uap:ShareTarget Description="Open in Compact View">
+            <uap:DataFormat>URI</uap:DataFormat>
+          </uap:ShareTarget>
+        </uap:Extension>
+      </Extensions>
     </Application>
   </Applications>
   <Capabilities>

--- a/CompactView/Views/WebViewPage.xaml.cs
+++ b/CompactView/Views/WebViewPage.xaml.cs
@@ -139,6 +139,11 @@ namespace CompactView.Views
 
         private async void MiniView_Click(object sender, RoutedEventArgs e)
         {
+            await EnterMiniView();
+        }
+
+        public async Task EnterMiniView()
+        {
             var view = ApplicationView.GetForCurrentView();
             if (!IsCompactview())
             {


### PR DESCRIPTION
I love the app and I decided to add one little feature that makes opening a new website a little easier: I implemented the W10 share contract so other apps (mainly intended for Edge) can share an URL to Compact View, and it will automatically launch, add the specified address to the bookmarks and load the page in compact overlay mode.

Since the share contract is intended to launch the app, perform the share action and close it afterwards, Windows does not launch a standalone app window but a modal one, so the launch had to be implemented in two phases:

- First, when the app is activated via the share contract, it will just generate and launch an uri which uses the custom protocol 'compactview:' and includes the original uri in the query.
- When the app is launched via uri activation, it will read the original browser url, add it to the WebsiteDataSource, load that specific page and activate the miniview.

As a side effect, this also means the user may create shortcuts for launching webpages using the app, using the following uri scheme: ` "compactview:?" + [escaped URL]`, for example a shortcut pointing to  `compactview:?https%3A%2F%2Fbing.com%2F` will load Bing.